### PR TITLE
Add node-gyp as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
       "bindings": "*"
   }
 , "devDependencies": {
-      "mocha": "> 0.7.0"
+      "mocha": "> 0.7.0",
+      "node-gyp": ">= 0.6.10"
     , "should": "*"
   }
 }


### PR DESCRIPTION
This seemed to fix issues i had compiling on 10.8,

When used with hook.io i got errors about wrong architecture.
