### PR TITLE
make proxy_container into a class; new/delete

### DIFF
--- a/src/weakref.cc
+++ b/src/weakref.cc
@@ -24,11 +24,12 @@ using namespace node;
 namespace {
 
 
-typedef struct proxy_container {
+class proxy_container {
+public:
   Persistent<Object> proxy;
   Persistent<Object> target;
   Persistent<Object> emitter;
-} proxy_container;
+};
 
 
 Persistent<ObjectTemplate> proxyClass;
@@ -152,7 +153,7 @@ NAN_WEAK_CALLBACK(void *, TargetCallback) {
   NanDispose(cont->proxy);
   NanDispose(cont->target);
   NanDispose(cont->emitter);
-  free(cont);
+  delete cont;
 }
 
 /**
@@ -163,8 +164,7 @@ NAN_METHOD(Create) {
   NanScope();
   if (!args[0]->IsObject()) return NanThrowTypeError("Object expected");
 
-  proxy_container *cont = (proxy_container *)
-    malloc(sizeof(proxy_container));
+  proxy_container *cont = new proxy_container();
 
   Local<Object> proxy = NanPersistentToLocal(proxyClass)->NewInstance();
   NanAssignPersistent(Object, cont->proxy, proxy);


### PR DESCRIPTION
Like this. Tests pass in 0.11.8, 0.10.22 and 0.8.25 with these changes.

The difference between the old way of assigning `Persistent` references and the new way is this (this is from nan.h):

``` c++
// old
handle = v8::Persistent<type>::New(obj);
// new
handle.Reset(nan_isolate, obj);
```

Since you can't just assign to a `handle` variable now you need an existing empty handle to `Reset()` to. If we make `proxy_container` into a class then we get empty handles initialised on `new` which we can then `Reset()` while old V8 can reassign.
