### PR TITLE
Fix missing HandleScope in callback

### DIFF
--- a/src/weakref.cc
+++ b/src/weakref.cc
@@ -133,6 +133,7 @@ NAN_PROPERTY_ENUMERATOR(WeakPropertyEnumerator) {
  */
 
 static void TargetCallback(const Nan::WeakCallbackInfo<proxy_container> &info) {
+  Nan::HandleScope scope;
   proxy_container *cont = info.GetParameter();
 
   // invoke global callback function


### PR DESCRIPTION
This is, I believe, the correct fix for #65, #66.

Error is very obvious while running node in debug mode. Line 140 will cause a crash because there's no HandleScope.