### PR TITLE
Add xcode_settings entry in binding.gyp to fix Mojave linker issue.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,6 +4,9 @@
     'sources': [ 'src/weakref.cc' ],
     'include_dirs': [
       '<!(node -e "require(\'nan\')")'
-    ]
+    ],
+    'xcode_settings': {
+      'MACOSX_DEPLOYMENT_TARGET': '10.9'
+    }
   }]
 }


### PR DESCRIPTION
Starting with macOS Mojave, building this package would result in this error: